### PR TITLE
imageloader: Fix -Wsometimes-uninitialized

### DIFF
--- a/src/imageloader.c
+++ b/src/imageloader.c
@@ -103,7 +103,7 @@ Image* zu4_img_load(U4FILE *file, int width, int height, int bpp, int type) {
 	uint8_t *compressed = NULL;
 	uint32_t *converted = (uint32_t*)malloc(width * height * sizeof(uint32_t));
 
-	long rawLen;
+	long rawLen = 0;
 	long compressedLen;
 
 	if (type == ZU4_IMG_RAW) {


### PR DESCRIPTION
With clang-15.0.2.
```
src/imageloader.c:121:11: warning: variable 'rawLen' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
        else if (type == ZU4_IMG_LZW) {
                 ^~~~~~~~~~~~~~~~~~~
src/imageloader.c:129:6: note: uninitialized use occurs here
        if (rawLen != (width * height * bpp / 8)) {
            ^~~~~~
src/imageloader.c:121:7: note: remove the 'if' if its condition is always true
        else if (type == ZU4_IMG_LZW) {
             ^~~~~~~~~~~~~~~~~~~~~~~~~
src/imageloader.c:106:13: note: initialize the variable 'rawLen' to silence this warning
        long rawLen;
                   ^
                    = 0
1 warning generated.
```